### PR TITLE
provide gh token to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Build python package
         run: poetry build
       - name: Run tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: poetry run pytest
       - uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
GitHub automatically creates a GITHUB_TOKEN secret to use in your workflow. You can use the GITHUB_TOKEN to authenticate in a workflow run.

https://docs.github.com/en/actions/reference/authentication-in-a-workflow